### PR TITLE
feature: Adds columns to KeySelector

### DIFF
--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -1,4 +1,6 @@
 use std::num::NonZero;
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 
 use lru::LruCache;
 use notatin::cell_key_node::CellKeyNode;
@@ -19,6 +21,15 @@ pub struct Navigation {
     pub table_states: CurrentKeyState,
     pub key_state_cache: LruCache<usize, TableState>,
     pub value_state_cache: LruCache<usize, TableState>,
+    pub key_sort_method: KeySort,
+}
+
+#[derive(Copy, Clone, Default, Debug, EnumIter, PartialEq, Eq, PartialOrd, Ord)]
+pub enum KeySort {
+    #[default]
+    SubkeyCount = 0,
+    KeyName = 1,
+    LastWrite = 2,
 }
 
 impl Navigation {
@@ -38,6 +49,7 @@ impl Navigation {
             selected_value: None,
             key_state_cache: LruCache::new(NonZero::new(200).unwrap()),
             value_state_cache: LruCache::new(NonZero::new(200).unwrap()),
+            key_sort_method: KeySort::default(),
         }
         .with_selected_key(current_key.clone())
     }
@@ -45,6 +57,33 @@ impl Navigation {
     pub fn with_selected_key(mut self, key: CellKeyNode) -> Self {
         self.select_key(key);
         self
+    }
+
+    pub fn sort_subkeys(&mut self, sort_type: KeySort) {
+        match sort_type {
+            KeySort::LastWrite => self
+                .current_subkeys
+                .sort_by_key(|key| key.last_key_written_date_and_time()),
+            KeySort::KeyName => self.current_subkeys.sort_by_key(|key| key.key_name.clone()),
+            KeySort::SubkeyCount => self
+                .current_subkeys
+                .sort_by_key(|key| key.detail.number_of_sub_keys()),
+        }
+        if let Some(ref sk) = self.selected_subkey {
+            let index = self.current_subkeys.iter().position(|key| *sk == *key);
+            self.table_states.key_selector_state.select(index)
+        }
+        self.key_sort_method = sort_type;
+    }
+
+    pub fn change_subkey_sort(&mut self) {
+        self.sort_subkeys(
+            KeySort::iter()
+                .cycle()
+                .skip_while(|sort| *sort != self.key_sort_method)
+                .nth(1)
+                .expect("There to be a continuous iterator"),
+        )
     }
 
     pub fn select_key(&mut self, key: CellKeyNode) {

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -97,10 +97,8 @@ impl Navigation {
     }
 
     pub fn leave_key(&mut self) {
-        if let Ok(parent_key) = self.parser.get_parent_key(&mut self.current_key) {
-            if let Some(key) = parent_key {
-                self.select_key(key.clone());
-            }
+        if let Ok(Some(parent_key)) = self.parser.get_parent_key(&mut self.current_key) {
+            self.select_key(parent_key.clone());
         }
     }
 
@@ -151,8 +149,7 @@ impl Navigation {
             self.current_key
                 .cell_sub_key_offsets_absolute
                 .len()
-                .checked_sub(1)
-                .unwrap_or(0),
+                .saturating_sub(1),
         );
 
         self.table_states.key_selector_state.select(Some(new_index));
@@ -170,7 +167,7 @@ impl Navigation {
         if let Some(subkey) = &self.selected_subkey {
             let new_index = std::cmp::min(
                 std::cmp::max(0, index as isize + n_keys) as usize,
-                subkey.value_iter().count().checked_sub(1).unwrap_or(0),
+                subkey.value_iter().count().saturating_sub(1),
             );
             self.table_states
                 .value_selector_state

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -51,6 +51,11 @@ pub fn handle_key_selector_key_events(key_event: KeyEvent, app: &mut App) -> App
                 app.state.navigation.change_subkey_by(-1)
             }
         }
+        KeyCode::Char('s') => {
+            if key_event.modifiers == KeyModifiers::CONTROL {
+                app.state.navigation.change_subkey_sort();
+            }
+        }
         _ => {}
     }
     Ok(())

--- a/src/widgets/key_selector.rs
+++ b/src/widgets/key_selector.rs
@@ -1,3 +1,4 @@
+use crate::app::navigation::KeySort;
 use crate::app::state::{FocusedPane, State};
 use notatin::cell_key_node::CellKeyNode;
 use ratatui::layout::Constraint;
@@ -25,6 +26,7 @@ pub struct UIKey<'cell> {
 
 pub struct UIKeySet<'cell> {
     keys: Vec<&'cell CellKeyNode>,
+    sort_column: KeySort,
     focused: bool,
 }
 
@@ -59,6 +61,7 @@ fn make_table_block(focused: bool) -> Block<'static> {
 impl From<UIKeySet<'_>> for Table<'_> {
     fn from(value: UIKeySet<'_>) -> Self {
         let mut styles = [Style::default(); 3];
+        styles[value.sort_column as usize].bg = Some(Color::DarkGray);
 
         let rows = value
             .keys
@@ -122,6 +125,7 @@ impl StatefulWidget for &mut KeySelector {
         let table = Table::from(UIKeySet {
             keys: state.navigation.current_subkeys.iter().collect(),
             focused: state.focused_pane == FocusedPane::KeySelector,
+            sort_column: state.navigation.key_sort_method,
         });
 
         <Table as StatefulWidget>::render(

--- a/src/widgets/key_selector.rs
+++ b/src/widgets/key_selector.rs
@@ -1,4 +1,7 @@
-use crate::app::state::{State, FocusedPane};
+use crate::app::state::{FocusedPane, State};
+use notatin::cell_key_node::CellKeyNode;
+use ratatui::layout::Constraint;
+use ratatui::style::Stylize;
 use ratatui::text::Text;
 use ratatui::widgets::StatefulWidget;
 use ratatui::{
@@ -9,10 +12,106 @@ use ratatui::{
     text::Line,
     widgets::{block::*, *},
 };
+use std::convert::Into;
 
 use ratatui::prelude::Alignment;
 
 pub struct KeySelector;
+
+pub struct UIKey<'cell> {
+    key: &'cell CellKeyNode,
+    styles: [Style; 3],
+}
+
+pub struct UIKeySet<'cell> {
+    keys: Vec<&'cell CellKeyNode>,
+    focused: bool,
+}
+
+fn make_table_block(focused: bool) -> Block<'static> {
+    let title = Title::from("subkeys".to_string());
+    let instructions = Title::from(Line::from(vec![
+        " Enter Subkey ".into(),
+        "<L>".blue().bold(),
+        " Go to parent key ".into(),
+        "<H>".blue().bold(),
+        " Quit ".into(),
+        "<Q> ".blue().bold(),
+    ]));
+    Block::default()
+        .title(title.alignment(Alignment::Center))
+        .title(
+            instructions
+                .alignment(Alignment::Center)
+                .position(Position::Bottom),
+        )
+        .borders(Borders::ALL)
+        .border_set(match focused {
+            true => border::THICK,
+            false => border::PLAIN,
+        })
+        .border_style(match focused {
+            true => Color::Green,
+            false => Color::default(),
+        })
+}
+
+impl From<UIKeySet<'_>> for Table<'_> {
+    fn from(value: UIKeySet<'_>) -> Self {
+        let mut styles = [Style::default(); 3];
+
+        let rows = value
+            .keys
+            .iter()
+            .map(|key| UIKey { key, styles }.into())
+            .collect::<Vec<Row>>();
+
+        let widest_count = value
+            .keys
+            .iter()
+            .map(|key| key.detail.number_of_sub_keys().to_string().len())
+            .max()
+            .unwrap_or(0);
+
+        let widest_key = value
+            .keys
+            .iter()
+            .map(|key| key.key_name.len())
+            .max()
+            .unwrap_or(0);
+
+        Table::new(
+            rows,
+            vec![
+                Constraint::Length(widest_count as u16),
+                Constraint::Fill(widest_key as u16),
+                Constraint::Length(24),
+            ],
+        )
+        .block(make_table_block(value.focused))
+        .highlight_style(Style::new().add_modifier(Modifier::BOLD))
+        .highlight_symbol(Text::from("|").blue())
+    }
+}
+
+impl From<UIKey<'_>> for Row<'_> {
+    fn from(val: UIKey<'_>) -> Self {
+        Row::new([
+            Cell::new(format!("{}", val.key.detail.number_of_sub_keys())).style(val.styles[0]),
+            Cell::new(val.key.key_name.clone()).style(val.styles[1]),
+            Cell::new(
+                Text::from(
+                    val.key
+                        .last_key_written_date_and_time()
+                        .to_utc()
+                        .to_string(),
+                )
+                .alignment(Alignment::Right),
+            )
+            .style(val.styles[2]),
+        ])
+    }
+}
 
 impl StatefulWidget for &mut KeySelector {
     type State = State;
@@ -20,44 +119,10 @@ impl StatefulWidget for &mut KeySelector {
     where
         Self: Sized,
     {
-        let title = Title::from("subkeys".to_string());
-        let instructions = Title::from(Line::from(vec![
-            " Enter Subkey ".into(),
-            "<L>".blue().bold(),
-            " Go to parent key ".into(),
-            "<H>".blue().bold(),
-            " Quit ".into(),
-            "<Q> ".blue().bold(),
-        ]));
-        let block = Block::default()
-            .title(title.alignment(Alignment::Center))
-            .title(
-                instructions
-                    .alignment(Alignment::Center)
-                    .position(Position::Bottom),
-            )
-            .borders(Borders::ALL)
-            .border_set(match state.focused_pane {
-                FocusedPane::KeySelector => border::THICK,
-                _ => border::PLAIN,
-            })
-            .border_style(match state.focused_pane {
-                FocusedPane::KeySelector => Color::Green,
-                _ => Color::default(),
-            });
-
-        let rows: Vec<Row> = state
-            .navigation
-            .current_key
-            .read_sub_keys(&mut state.navigation.parser)
-            .iter()
-            .map(|key| Row::new(vec![Cell::new(key.key_name.clone())]))
-            .collect::<Vec<Row>>();
-
-        let table = Table::new(rows, vec![80])
-            .block(block)
-            .highlight_style(Style::new().add_modifier(Modifier::BOLD))
-            .highlight_symbol(Text::from("|").blue());
+        let table = Table::from(UIKeySet {
+            keys: state.navigation.current_subkeys.iter().collect(),
+            focused: state.focused_pane == FocusedPane::KeySelector,
+        });
 
         <Table as StatefulWidget>::render(
             table,


### PR DESCRIPTION
resolves #10

This adds each subkey's last write time, as well as its subkey counts, to new cells in 
the `KeySelector` table widget. This is some bare-minimum useful information to 
have available when navigating the list. 

Also adds sorting on Key name, last write time, and subkey count in the
`KeySelector` widget. Decided to do this at the same time as https://github.com/orogenicbelt/hiview/issues/10 since
it also required changing the column highlight, and it became clear that
things weren't structured well as I continued to write this feature.
Keys/Subkeys are now wrapped in structs that provide a `From` trait
implementation for converting to their respective `Table`/`Row` ratatui
UI components.

@orogenicbelt I ended up knocking out two issues during development, but I'm
happy to split this into two branches and PRs if you prefer.